### PR TITLE
Cpf Cnpj pipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ Transform string in CNPJ like format.
 ```html
 {{'99999999999999' | cnpj}} // output 99.999.999/9999-99
 ```
+### CpfCnpjPipe
+
+Transform string in CPF/CNPJ like format.
+
+```html
+{{'01964256119' | cpf}} // output 019.642.561-19
+{{'99999999999999' | cnpj}} // output 99.999.999/9999-99
+```
 
 ### CepPipe
 

--- a/README.md
+++ b/README.md
@@ -53,11 +53,11 @@ Transform string in CNPJ like format.
 ```
 ### CpfCnpjPipe
 
-Transform string in CPF/CNPJ like format.
+Transform string in CPF or CNPJ like format. Accepts both types.
 
 ```html
-{{'01964256119' | cpf}} // output 019.642.561-19
-{{'99999999999999' | cnpj}} // output 99.999.999/9999-99
+{{'01964256119' | cpfCnpj}} // output 019.642.561-19
+{{'99999999999999' | cpfCnpj}} // output 99.999.999/9999-99
 ```
 
 ### CepPipe

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ng2-brpipes",
-    "version": "1.1.4",
+    "version": "1.2.0",
     "description": "Angular2 pipes for BR types",
     "files": [
         "src/*.d.ts",

--- a/src/br-pipes.module.ts
+++ b/src/br-pipes.module.ts
@@ -1,3 +1,4 @@
+import { CpfCnpjPipe } from './cpf-cnpj.pipe';
 import { RealPipe } from './real.pipe';
 import { CeiPipe } from './cei.pipe';
 import { TelefonePipe } from './telefone.pipe';
@@ -11,6 +12,7 @@ import { NgModule } from '@angular/core';
         CepPipe,
         CnpjPipe,
         CpfPipe,
+        CpfCnpjPipe,
         TelefonePipe,
         CeiPipe,
         RealPipe
@@ -19,6 +21,7 @@ import { NgModule } from '@angular/core';
         CepPipe,
         CnpjPipe,
         CpfPipe,
+        CpfCnpjPipe,
         TelefonePipe,
         CeiPipe,
         RealPipe

--- a/src/cnpj.pipe.ts
+++ b/src/cnpj.pipe.ts
@@ -1,4 +1,4 @@
-import { isString } from './utils';
+import { isString, formatCnpj } from './utils';
 import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({
@@ -12,7 +12,7 @@ export class CnpjPipe implements PipeTransform {
         }
 
         if(value && value.length === 14) {
-            return `${value.substr(0, 2)}.${value.substr(2, 3)}.${value.substr(5, 3)}/${value.substr(8, 4)}-${value.substr(12, 2)}`;
+            return formatCnpj(value);
         }
 
         return value;

--- a/src/cnpj.pipe.ts
+++ b/src/cnpj.pipe.ts
@@ -1,4 +1,4 @@
-import { isString, formatCnpj } from './utils';
+import { isString, formatCnpj, removeNonDigits } from './utils';
 import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({
@@ -11,8 +11,10 @@ export class CnpjPipe implements PipeTransform {
             return value;
         }
 
-        if(value && value.length === 14) {
-            return formatCnpj(value);
+        const onlyDigits = removeNonDigits(value);
+
+        if(onlyDigits && onlyDigits.length === 14) {
+            return formatCnpj(onlyDigits);
         }
 
         return value;

--- a/src/cpf-cnpj.pipe.ts
+++ b/src/cpf-cnpj.pipe.ts
@@ -1,11 +1,11 @@
-import { isString, formatCpf } from './utils';
+import { isString, formatCpf, formatCnpj } from './utils';
 import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({
-    name: 'cpf'
+    name: 'cpfCnpj'
 })
-// 019.642.561-19
-export class CpfPipe implements PipeTransform {
+// 019.642.561-19 || 99.999.999/9999-99
+export class CpfCnpjPipe implements PipeTransform {
     transform(value: any): any {
         if (!isString(value)) {
             return value;
@@ -13,6 +13,8 @@ export class CpfPipe implements PipeTransform {
 
         if(value && value.length === 11) {
             return formatCpf(value);
+        } else if (value && value.length === 14) {
+            return formatCnpj(value);
         }
 
         return value;

--- a/src/cpf-cnpj.pipe.ts
+++ b/src/cpf-cnpj.pipe.ts
@@ -1,4 +1,4 @@
-import { isString, formatCpf, formatCnpj } from './utils';
+import { isString, formatCpf, formatCnpj, removeNonDigits } from './utils';
 import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({
@@ -11,10 +11,12 @@ export class CpfCnpjPipe implements PipeTransform {
             return value;
         }
 
-        if(value && value.length === 11) {
-            return formatCpf(value);
-        } else if (value && value.length === 14) {
-            return formatCnpj(value);
+        const onlyDigits = removeNonDigits(value);
+
+        if(onlyDigits && onlyDigits.length === 11) {
+            return formatCpf(onlyDigits);
+        } else if (onlyDigits && onlyDigits.length === 14) {
+            return formatCnpj(onlyDigits);
         }
 
         return value;

--- a/src/cpf.pipe.ts
+++ b/src/cpf.pipe.ts
@@ -1,4 +1,4 @@
-import { isString, formatCpf } from './utils';
+import { isString, formatCpf, removeNonDigits } from './utils';
 import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({
@@ -10,9 +10,10 @@ export class CpfPipe implements PipeTransform {
         if (!isString(value)) {
             return value;
         }
+        const onlyDigits = removeNonDigits(value);
 
-        if(value && value.length === 11) {
-            return formatCpf(value);
+        if(onlyDigits && onlyDigits.length === 11) {
+            return formatCpf(onlyDigits);
         }
 
         return value;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,5 +3,6 @@ export * from './cei.pipe';
 export * from './telefone.pipe';
 export * from './cpf.pipe';
 export * from './cnpj.pipe';
+export * from './cpf-cnpj.pipe';
 export * from './cep.pipe';
 export * from './br-pipes.module';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,3 +7,13 @@ export function hasLength(value: any): boolean {
 
     return value.toString().trim().length > 0;
 }
+
+export function formatCnpj(value: string): string {
+
+    return `${value.substr(0, 2)}.${value.substr(2, 3)}.${value.substr(5, 3)}/${value.substr(8, 4)}-${value.substr(12, 2)}`;
+}
+
+export function formatCpf(value: string): string {
+
+    return `${value.substr(0, 3)}.${value.substr(3, 3)}.${value.substr(6, 3)}-${value.substr(9, 2)}`;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,6 +8,10 @@ export function hasLength(value: any): boolean {
     return value.toString().trim().length > 0;
 }
 
+export function removeNonDigits(value: string): string {
+    return value.replace(/\D/g,'');
+}
+
 export function formatCnpj(value: string): string {
 
     return `${value.substr(0, 2)}.${value.substr(2, 3)}.${value.substr(5, 3)}/${value.substr(8, 4)}-${value.substr(12, 2)}`;

--- a/test/cep.pipe.spec.ts
+++ b/test/cep.pipe.spec.ts
@@ -1,11 +1,12 @@
-import { CnpjPipe } from '../src/cnpj.pipe';
-describe('CnpjPipe', () => {
-  
-  let pipe = new CnpjPipe();
-  it('transforms "43146822000198" to "43.146.822/0001-98"', () => {
-    expect(pipe.transform('43146822000198')).toBe('43.146.822/0001-98');
-  });
+import { CepPipe } from '../src/cep.pipe';
 
+describe('CepPipe', () => {
+  
+  let pipe = new CepPipe();
+  it('transforms "72006226" to "72006-226"', () => {
+    expect(pipe.transform('72006226')).toBe('72006-226');
+  });
+  
   it('transforms null to null', () => {
     expect(pipe.transform(null)).toBe(null);
   });

--- a/test/cnpj.pipe.spec.ts
+++ b/test/cnpj.pipe.spec.ts
@@ -1,12 +1,11 @@
-import { CepPipe } from '../src/cep.pipe';
-
-describe('CepPipe', () => {
+import { CnpjPipe } from '../src/cnpj.pipe';
+describe('CnpjPipe', () => {
   
-  let pipe = new CepPipe();
-  it('transforms "72006226" to "72006-226"', () => {
-    expect(pipe.transform('72006226')).toBe('72006-226');
+  let pipe = new CnpjPipe();
+  it('transforms "43146822000198" to "43.146.822/0001-98"', () => {
+    expect(pipe.transform('43146822000198')).toBe('43.146.822/0001-98');
   });
-  
+
   it('transforms null to null', () => {
     expect(pipe.transform(null)).toBe(null);
   });

--- a/test/cpf-cnpj.pipe.spec.ts
+++ b/test/cpf-cnpj.pipe.spec.ts
@@ -1,6 +1,6 @@
 import { CpfCnpjPipe } from './../src/cpf-cnpj.pipe';
 
-describe('CpfPipe', () => {
+describe('CpfCnpjPipe', () => {
   
   let pipe = new CpfCnpjPipe();
   it('transforms "01964256119" to "019.642.561-19"', () => {

--- a/test/cpf-cnpj.pipe.spec.ts
+++ b/test/cpf-cnpj.pipe.spec.ts
@@ -1,0 +1,34 @@
+import { CpfCnpjPipe } from './../src/cpf-cnpj.pipe';
+
+describe('CpfPipe', () => {
+  
+  let pipe = new CpfCnpjPipe();
+  it('transforms "01964256119" to "019.642.561-19"', () => {
+    expect(pipe.transform('01964256119')).toBe('019.642.561-19');
+  });
+
+  it('transforms "019.642.561-19" to "019.642.561-19"', () => {
+    expect(pipe.transform('019.642.561-19')).toBe('019.642.561-19');
+  });
+  
+  it('transforms null to null', () => {
+    expect(pipe.transform(null)).toBe(null);
+  });
+
+  it('transforms undefined to undefined', () => {
+    expect(pipe.transform(undefined)).toBe(undefined);
+  });
+
+  it('transforms "" to ""', () => {
+    expect(pipe.transform('')).toBe('');
+  });
+
+  it('transforms "33154" to "33154"', () => {
+    expect(pipe.transform('33154')).toBe('33154');
+  });
+
+  it('transforms "43146822000198" to "43.146.822/0001-98"', () => {
+    expect(pipe.transform('43146822000198')).toBe('43.146.822/0001-98');
+  });
+
+});


### PR DESCRIPTION
Cria pipe para formatar CPF ou CNPJ.

Identifica se o valor é um CPF ou CNPJ e o formata. 

É útil quando o mesmo campo pode armazenar um dado ou outro.